### PR TITLE
Upgrade Matter SDK to v1.1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,10 @@ Discover using DNS-SD and pair:
 sudo chip-tool pairing onnetwork 110 20202021
 ```
 
-Or, pair directly by giving the IP address:
-```bash
-sudo chip-tool pairing ethernet 110 20202021 3840 192.168.1.110 5543
-```
-
 where:
 
 -   `110` is the node id being assigned to the app
 -   `20202021` is the pin code set on the app
--   `3840` is the discriminator id
--   `192.168.1.110` is the IP address of the device running the app
--   `5540` the port for server that runs inside the app
 
 ### Commissioning into Thread network over BLE
 Obtain Thread network credential:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.0.0.2
+      - TAG: v1.1.0.1
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .


### PR DESCRIPTION
For the `chip-tool pairing` command, the `ethernet` subcommand has been removed, and the following six new commands have been added in the latest version v1.1.0.1:
```
 already-discovered                                                                
 already-discovered-by-index                                                       
 already-discovered-by-index-with-wifi      
 get-commissioner-node-id                                                          
 get-commissioner-root-certificate  
 issue-noc-chain       
 ```
 #### Test
 The snap built from this PR has already been tested for pairing and controlling the matter-bridge-tapo-light snap using:
 ```
 sudo chip-tool pairing onnetwork 110 20202021
 sudo chip-tool onoff toggle 110 1
 ```