### PR TITLE
Revert "Upgrade Matter SDK to v1.1.0.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ Discover using DNS-SD and pair:
 sudo chip-tool pairing onnetwork 110 20202021
 ```
 
+Or, pair directly by giving the IP address:
+```bash
+sudo chip-tool pairing ethernet 110 20202021 3840 192.168.1.110 5543
+```
+
 where:
 
 -   `110` is the node id being assigned to the app
 -   `20202021` is the pin code set on the app
+-   `3840` is the discriminator id
+-   `192.168.1.110` is the IP address of the device running the app
+-   `5540` the port for server that runs inside the app
 
 ### Commissioning into Thread network over BLE
 Obtain Thread network credential:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.1.0.1
+      - TAG: v1.0.0.2
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .


### PR DESCRIPTION
Reverting canonical/chip-tool-snap#2 because the `arm64` build requires additional changes: https://github.com/canonical/chip-tool-snap/issues/3

The `amd64` revision will be still available under `latest/edge/1.1` channel in the next 30 days.