### PR TITLE
Change snap grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ description: Refer to https://snapcraft.io/chip-tool
 adopt-info: connectedhomeip
 
 confinement: strict
-grade: devel
+grade: stable
 license: Apache-2.0
 
 base: core22


### PR DESCRIPTION
The snap built from SDK v1.0.0.2 has been tested for a while without any reported issue. It is considered stable.