### PR TITLE
Upgrade Matter SDK to v1.1.0.1, add build packages for arm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,10 @@ Discover using DNS-SD and pair:
 sudo chip-tool pairing onnetwork 110 20202021
 ```
 
-Or, pair directly by giving the IP address:
-```bash
-sudo chip-tool pairing ethernet 110 20202021 3840 192.168.1.110 5543
-```
-
 where:
 
 -   `110` is the node id being assigned to the app
 -   `20202021` is the pin code set on the app
--   `3840` is the discriminator id
--   `192.168.1.110` is the IP address of the device running the app
--   `5540` the port for server that runs inside the app
 
 ### Commissioning into Thread network over BLE
 Obtain Thread network credential:

--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ Discover using DNS-SD and pair:
 sudo chip-tool pairing onnetwork 110 20202021
 ```
 
+Or, pair directly by giving the IP address:
+```bash
+sudo chip-tool pairing ethernet 110 20202021 3840 192.168.1.110 5543
+```
+
 where:
 
 -   `110` is the node id being assigned to the app
 -   `20202021` is the pin code set on the app
+-   `3840` is the discriminator id
+-   `192.168.1.110` is the IP address of the device running the app
+-   `5540` the port for server that runs inside the app
 
 ### Commissioning into Thread network over BLE
 Obtain Thread network credential:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.1.0.1
+      - TAG: v1.0.0.2
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.0.0.2
+      - TAG: v1.1.0.1
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,7 +117,6 @@ parts:
       - libgif-dev 
       - librsvg2-dev
       - wget
-      - curl
 
 apps:
   chip-tool:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.0.0.2
+      - TAG: v1.1.0.1
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .
@@ -36,6 +36,37 @@ parts:
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/bin
 
+      # Install NodeJS and ZAP tool for arm builds
+      if [[ $SNAP_ARCH == "arm64" ]]; then
+        set -x
+
+        mkdir node_js
+        cd node_js
+        wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz
+        tar xfvJ node-v12.22.12-linux-x64.tar.xz
+        cp -rn node-v12.22.12-linux-x64/. /opt/node-v12.22.12-linux-x64/
+        rm -r node-v12.22.12-linux-x64
+        rm -rf /opt/node
+        rm -rf /usr/bin/node
+        rm -rf /usr/bin/npm
+        rm -rf /usr/bin/npx
+        ln -s /opt/node-v12.22.12-linux-x64 /opt/node
+        ln -s /opt/node/bin/* /usr/bin
+        cd ..
+        rm -rf node_js
+
+        ZAP_VERSION=v2023.05.22-nightly
+        mkdir -p /opt/zap-${ZAP_VERSION}
+        git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
+        cd /opt/zap-${ZAP_VERSION}
+        git checkout -b ${ZAP_VERSION}
+        npm cache clean --force
+        npm install -g npm@latest
+        npm ci
+        export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
+      fi
+
+      cd $CRAFT_PART_BUILD
       cd ../../connectedhomeip/src
       
       # The project writes its data to /tmp which isn't persisted.
@@ -80,6 +111,13 @@ parts:
       - libcairo2-dev
       - libreadline-dev
       - generate-ninja
+      - build-essential 
+      - libpango1.0-dev 
+      - libjpeg-dev 
+      - libgif-dev 
+      - librsvg2-dev
+      - wget
+      - curl
 
 apps:
   chip-tool:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
   connectedhomeip:
     plugin: nil
     build-environment:
-      - TAG: v1.1.0.1
+      - TAG: v1.0.0.2
     override-pull: |
       # shallow clone the project its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$TAG .
@@ -71,37 +71,6 @@ parts:
       test -f $ZAP_ENV && source $ZAP_ENV
       mkdir -p $CRAFT_PART_INSTALL/bin
 
-      # Install NodeJS and ZAP tool for arm builds
-      if [[ $SNAP_ARCH == "arm64" ]]; then
-        set -x
-
-        mkdir node_js
-        cd node_js
-        wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz
-        tar xfvJ node-v12.22.12-linux-x64.tar.xz
-        cp -rn node-v12.22.12-linux-x64/. /opt/node-v12.22.12-linux-x64/
-        rm -r node-v12.22.12-linux-x64
-        rm -rf /opt/node
-        rm -rf /usr/bin/node
-        rm -rf /usr/bin/npm
-        rm -rf /usr/bin/npx
-        ln -s /opt/node-v12.22.12-linux-x64 /opt/node
-        ln -s /opt/node/bin/* /usr/bin
-        cd ..
-        rm -rf node_js
-
-        ZAP_VERSION=v2023.05.22-nightly
-        mkdir -p /opt/zap-${ZAP_VERSION}
-        git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION}
-        cd /opt/zap-${ZAP_VERSION}
-        git checkout -b ${ZAP_VERSION}
-        npm cache clean --force
-        npm install -g npm@latest
-        npm ci
-        export ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
-      fi
-
-      cd $CRAFT_PART_BUILD
       cd ../../connectedhomeip/src
       
       # The project writes its data to /tmp which isn't persisted.
@@ -146,12 +115,6 @@ parts:
       - libcairo2-dev
       - libreadline-dev
       - generate-ninja
-      - build-essential 
-      - libpango1.0-dev 
-      - libjpeg-dev 
-      - libgif-dev 
-      - librsvg2-dev
-      - wget
 
 apps:
   chip-tool:


### PR DESCRIPTION
This PR references the upstream [Dockerffile](https://github.com/project-chip/connectedhomeip/blob/master/integrations/docker/images/chip-cert-bins/Dockerfile#L174-L196) and [code_generation.md](https://github.com/project-chip/connectedhomeip/blob/master/docs/code_generation.md#installing-zap-and-environment-variables).

#### Testing
### Testing
I have tested the chip-tool snap built from this PR locally, with the matter-pi-gpio-commander snap built from [this PR](https://github.com/canonical/matter-pi-gpio-commander/pull/20), and they both work as expected using the same version of Matter SDK v1.1.0.1. The chip-tool snap could commission and control matter-pi-gpio-commander snap.

build:
```
snapcraft -v --debug
```
install and setup chip-tool:
```
sudo snap install ./chip-tool_v1.1.0.1+snap_arm64.snap --dangerous
sudo snap connect chip-tool:avahi-observe
sudo snap connect chip-tool:bluez
```
install and setup matter-pi-gpio-commander:
```
sudo snap install ./matter-pi-gpio-commander_0.3.0_arm64.snap --dangerous
sudo snap set matter-pi-gpio-commander gpio=26

sudo snap connect matter-pi-gpio-commander:avahi-control
sudo snap connect matter-pi-gpio-commander:gpio-memory-control
sudo snap start matter-pi-gpio-commander
```

commison and control:
```
sudo chip-tool pairing onnetwork 110 20202021
sudo chip-tool onoff toggle 110 1
```

Upon successful execution, the LED on the Pi should be controlled by Chip Tool, turning it on or off.

Closes #3 