### PR TITLE
Remove non-core Python build requirements

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,7 @@ parts:
     override-build: |
       # Setup ZAP paths; installed in the corresponding part
       test -f $ZAP_ENV && source $ZAP_ENV
+
       mkdir -p $CRAFT_PART_INSTALL/bin
 
       cd ../../connectedhomeip/src
@@ -90,10 +91,19 @@ parts:
       # Replace key-value store path:
       sed -i 's/\/tmp/\/mnt/g' src/platform/Linux/CHIPPlatformConfig.h
 
-      # to avoid activation errors, don't treat unset variables as error
+      # To avoid activation errors, don't treat unset variables as error
       set +u 
 
-      # build the chip tool
+      # Installing gevent (from esp32 requirements) fails with Python 3.10
+      # See: https://github.com/project-chip/connectedhomeip/issues/28435
+      #
+      # The latest bootstrap script accepts a --platform flag which makes it
+      #   possible to skip unneeded platform packages.
+      #
+      # For v1.1.0.1, we'll skip the problematic package manually:
+      sed -i '/^gdbgui/ s/./#&/' ./scripts/setup/requirements.esp32.txt
+
+      # Build the chip tool
       ./scripts/examples/gn_build_example.sh examples/chip-tool ./build-examples
       
       cp build-examples/chip-tool $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,14 +94,8 @@ parts:
       # To avoid activation errors, don't treat unset variables as error
       set +u 
 
-      # Installing gevent (from esp32 requirements) fails with Python 3.10
-      # See: https://github.com/project-chip/connectedhomeip/issues/28435
-      #
-      # The latest bootstrap script accepts a --platform flag which makes it
-      #   possible to skip unneeded platform packages.
-      #
-      # For v1.1.0.1, we'll skip the problematic package manually:
-      sed -i '/^gdbgui/ s/./#&/' ./scripts/setup/requirements.esp32.txt
+      # Skip all non-core Python requirements:
+      sed -i '/^-r requirements/ s/./#&/' ./scripts/setup/requirements.txt
 
       # Build the chip tool
       ./scripts/examples/gn_build_example.sh examples/chip-tool ./build-examples


### PR DESCRIPTION
Originally reported at https://github.com/canonical/chip-tool-snap/pull/6#issuecomment-1676398315

The gevent package is a Python requirement for ESP32 on non-arm64 platforms. 

This PR fixes the issue by not only removing the problematic gevent package (https://github.com/canonical/chip-tool-snap/commit/605141294f2ed841b5f49de4eccd2a4905c1f77f), but by skipping all the non-core packages which aren't needed. In future versions, this should be done using the bootstrap script; see #10 

