### PR TITLE
Add process control plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Connect the [`bluez`](https://snapcraft.io/docs/bluez-interface) interface for d
 sudo snap connect chip-tool:bluez
 ```
 
-Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management, such as sched_setattr system call:
+Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management, 
+such as allow [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system call:
 ```bash
 sudo snap connect chip-tool:process-control
 ```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Connect the [`bluez`](https://snapcraft.io/docs/bluez-interface) interface for d
 sudo snap connect chip-tool:bluez
 ```
 
-Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management, 
-such as allow [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system call:
+Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management. This is needed to grant Chip Tool access to make [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system calls. This may improve the reliability of the operations (see #8).
 ```bash
 sudo snap connect chip-tool:process-control
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Connect the [`bluez`](https://snapcraft.io/docs/bluez-interface) interface for d
 sudo snap connect chip-tool:bluez
 ```
 
-Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management. This is needed to grant Chip Tool access to make [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system calls. This may improve the reliability of the operations (see #8).
+Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management. This is needed to grant Chip Tool access to make [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system calls. This may improve the reliability of the operations (see https://github.com/canonical/chip-tool-snap/issues/8).
 ```bash
 sudo snap connect chip-tool:process-control
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Connect the [`process-control`](https://snapcraft.io/docs/process-control-interf
 sudo snap connect chip-tool:process-control
 ```
 
+> **Note**  
+> On **Ubuntu Core**, the `avahi-control` and `bluez` interfaces are not provided by the system.
+>
+> These interfaces are provided by other snaps, such as the [Avahi](https://snapcraft.io/avahi) and [BlueZ](https://snapcraft.io/bluez) snaps.
+> To install the snaps and connect to the interfaces, run:
+> ```bash
+> sudo snap install avahi bluez
+> sudo snap connect chip-tool:avahi-observe avahi:avahi-observe
+> sudo snap connect chip-tool:bluez bluez:service
+> ```
+> 
+
 ### Commissioning into IP network
 Discover using DNS-SD and pair:
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,17 +25,10 @@ Connect the [`bluez`](https://snapcraft.io/docs/bluez-interface) interface for d
 sudo snap connect chip-tool:bluez
 ```
 
-> **Note**  
-> On **Ubuntu Core**, the `avahi-control` and `bluez` interfaces are not provided by the system.
-> These interfaces should be consumed from other snaps, such as the [Avahi](https://snapcraft.io/avahi) and [BlueZ](https://snapcraft.io/bluez) snaps.
-> 
-> To install the snaps, and establish connections for the `avahi-control` interface from the `avahi` snap, and the `service` interface from the `bluez` snap, run:
-> ```bash
-> sudo snap install avahi bluez
-> sudo snap connect chip-tool:avahi-observe avahi
-> sudo snap connect chip-tool:bluez bluez:service
-> ```
-> 
+Connect the [`process-control`](https://snapcraft.io/docs/process-control-interface) interface for system-wide process management, such as sched_setattr system call:
+```bash
+sudo snap connect chip-tool:process-control
+```
 
 ### Commissioning into IP network
 Discover using DNS-SD and pair:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ sudo snap connect chip-tool:bluez
 
 > **Note**  
 > On **Ubuntu Core**, the `avahi-control` and `bluez` interfaces are not provided by the system.
->
-> These interfaces are provided by other snaps, such as the [Avahi](https://snapcraft.io/avahi) and [BlueZ](https://snapcraft.io/bluez) snaps.
-> To install the snaps and connect to the interfaces, run:
+> These interfaces should be consumed from other snaps, such as the [Avahi](https://snapcraft.io/avahi) and [BlueZ](https://snapcraft.io/bluez) snaps.
+> 
+> To install the snaps, and establish connections for the `avahi-control` interface from the `avahi` snap, and the `service` interface from the `bluez` snap, run:
 > ```bash
 > sudo snap install avahi bluez
-> sudo snap connect chip-tool:avahi-observe avahi:avahi-observe
+> sudo snap connect chip-tool:avahi-observe avahi
 > sudo snap connect chip-tool:bluez bluez:service
 > ```
 > 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,6 +127,7 @@ apps:
       - network
       - bluez
       - avahi-observe
+      - process-control
     environment:
       # Replace the path for chip-tool configuration files
       TMPDIR: "/mnt"


### PR DESCRIPTION
This PR will resolve #8. As the issue described, there is a seccomp violation on a [sched_setattr](https://man7.org/linux/man-pages/man2/sched_setattr.2.html) system call, and [snappy-debug](https://snapcraft.io/docs/debug-snaps#heading--snappy-debug) suggests adding the process-control plug.

<p data-pm-slice="1 1 []">chip-tool toggle command success rates :</p>

process-control plug | without | with
-- | -- | --
chip-tool toggle command success rates | 8/10 (2 Delay)<br>9/10 (1 Timeout)<br>8/10 (2 Timeout)<br>9/10(1 Delay)<br>9/10 (1 Timeout) | 10/10<br>7/10 (3 Timeout)<br>10/10<br>10/10<br>9/10 (1 Timeout)

<p> Note: Timeout is a fatal error; Delay is not a fatal error.<br><br>Overall, using a process-control plug provides chip-tool snap with slightly higher success rates when controlling a device.</p>