### PR TITLE
Add network bind plug for interactive server

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -125,6 +125,7 @@ apps:
     command: bin/chip-tool
     plugs:
       - network
+      - network-bind
       - bluez
       - avahi-observe
       - process-control


### PR DESCRIPTION
This PR will resolve https://github.com/canonical/chip-tool-snap/issues/18

To install and configure the snap with the changes introduced by this PR, follow these steps:
```
$ sudo snap install chip-tool --channel=edge/pr-19

$ sudo snap connect chip-tool:avahi-observe
$ sudo snap connect chip-tool:bluez
$ sudo snap connect chip-tool:process-control

$ snap connections chip-tool 
Interface        Plug                       Slot              Notes
avahi-observe    chip-tool:avahi-observe    :avahi-observe    manual
bluez            chip-tool:bluez            :bluez            manual
network          chip-tool:network          :network          -
network-bind     chip-tool:network-bind     :network-bind     -
process-control  chip-tool:process-control  :process-control  manual
```

After installation, the interactive mode command should run without any errors:
```
$ sudo chip-tool interactive server
```
```
$ sudo chip-tool interactive start 
...
>>> pairing onnetwork 110 20202021
>>> onoff toggle 110 1
```
