### PR TITLE
Use pre-built zap binary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,7 @@ parts:
     after: [connectedhomeip, zap]
     plugin: nil
     build-environment:
-      - ZAP_ENV: /root/parts/zap/build/env
+      - ZAP_ENV: ../../zap/build/env
     override-build: |
       # Setup ZAP paths; installed in the corresponding part
       test -f $ZAP_ENV && source $ZAP_ENV

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,8 +44,7 @@ parts:
         unzip -o zap-linux-$SNAP_ARCH.zip
 
         # Define the environment needed for the app build
-        echo "CRAFT_PART_BUILD=$CRAFT_PART_BUILD"
-        echo "export ZAP_INSTALL_PATH=$CRAFT_PART_BUILD" >> env
+        echo "export ZAP_INSTALL_PATH=$PWD" >> env
       fi
       
   chip-tool:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,33 +32,20 @@ parts:
       
   zap:
     plugin: nil
-    source: https://github.com/project-chip/zap.git
-    source-depth: 1
-    source-tag: v2023.05.04
     build-environment:
-      - NODE_VERSION: v18.16.1
+      - ZAP_VERSION: v2023.09.28
     build-packages:
-      - build-essential 
-      - libpango1.0-dev 
-      - libjpeg-dev 
-      - libgif-dev 
-      - librsvg2-dev
       - wget
+      - unzip
     override-build: |
       if [[ $SNAP_ARCH == "arm64" ]]; then
-        # Install node+npm
-        NODE=node-$NODE_VERSION-linux-$SNAP_ARCH
-        wget https://nodejs.org/dist/$NODE_VERSION/$NODE.tar.xz
-        tar -xJf $NODE.tar.xz
-        export PATH=$PWD/$NODE/bin:$PATH
+        # Download and unzip the prebuilt ZAP (Zigbee Cluster Library configuration tool and generator) binary for the ARM64 architecture
+        wget --no-verbose https://github.com/project-chip/zap/releases/download/$ZAP_VERSION/zap-linux-$SNAP_ARCH.zip
+        unzip -o zap-linux-$SNAP_ARCH.zip
 
-        # Install zap
-        npm install
-        
         # Define the environment needed for the app build
-        echo "export PATH=$PWD/$NODE/bin:$PATH" > env
-        echo "export ZAP_DEVELOPMENT_PATH=$PWD" >> env
-        cat env
+        echo "CRAFT_PART_BUILD=$CRAFT_PART_BUILD"
+        echo "export ZAP_INSTALL_PATH=$CRAFT_PART_BUILD" >> env
       fi
       
   chip-tool:
@@ -114,7 +101,6 @@ parts:
       - python3-venv
       - python3-dev
       - python3-pip
-      - unzip
       - libgirepository1.0-dev
       - libcairo2-dev
       - libreadline-dev


### PR DESCRIPTION
This PR uses pre-built zap binary to increase the efficiency of the build process, and it will also resolve #22 in snapcraft remote-build