### PR TITLE
Fix commission and validation in thread tests

### DIFF
--- a/manual_thread_tests/remote_device_setup.go
+++ b/manual_thread_tests/remote_device_setup.go
@@ -186,8 +186,7 @@ func waitForLogMessageOnRemoteDevice(t *testing.T, snap string, expectedLog stri
 		time.Sleep(1 * time.Second)
 		t.Logf("Retry %d/%d: Waiting for expected content in logs: %s", i, maxRetry, expectedLog)
 
-		command := fmt.Sprintf("sudo journalctl --since \"%s\" --no-pager | grep \"%s\"|| true", start.Format("2006-01-02 15:04:05"), snap)
-		t.Logf(command)
+		command := fmt.Sprintf("sudo journalctl --utc --since \"%s\" --no-pager | grep \"%s\"|| true", start.UTC().Format("2006-01-02 15:04:05"), expectedLog)
 		logs := executeRemoteCommand(t, command)
 		if strings.Contains(logs, expectedLog) {
 			t.Logf("Found expected content in logs: %s", expectedLog)

--- a/manual_thread_tests/thread_commission_test.go
+++ b/manual_thread_tests/thread_commission_test.go
@@ -32,7 +32,7 @@ func TestAllClustersAppThread(t *testing.T) {
 	RemoteDeviceSetup(t)
 
 	t.Run("Commission", func(t *testing.T) {
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool pairing ble-thread 110 hex:"+trimmedActiveDataset+" 20202021 3840 2>&1")
+		stdout, _, _ := utils.Exec(t, "sudo chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
 		assert.NoError(t,
 			os.WriteFile("chip-tool-pairing.log", []byte(stdout), 0644),
 		)


### PR DESCRIPTION
- Commission via code, without using BLE
- Use UTC time on target to ensure consistent queries regardless of local/remote timezones
- Correct log query string