### PR TITLE
Use SDK v1.3.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ parts:
     plugin: nil
     build-environment:
       - BUILD_METADATA: snap
-      - CHIP_TAG: master
+      - CHIP_TAG: v1.3.0.0
     override-pull: |
       # shallow clone the project and its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$CHIP_TAG .


### PR DESCRIPTION
## Summary
Pin sdk version to 1.3.0.0

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->
Check if github workflow tests pass

<!-- Reminders:
 - Incremented the snap version - automatic
 - Added or updated tests - na
 - Updated the CI/CD pipelines - na
 - Updated the README(s) - na
 - Updated external documentation - na
-->
