### PR TITLE
Remove sudo from chip-tool commands in tests

### DIFF
--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -17,7 +17,7 @@ func TestAllClustersAppThread(t *testing.T) {
 	remote_setup(t)
 
 	t.Run("Commission", func(t *testing.T) {
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
 		assert.NoError(t,
 			os.WriteFile("chip-tool-thread-pairing.log", []byte(stdout), 0644),
 		)
@@ -25,7 +25,7 @@ func TestAllClustersAppThread(t *testing.T) {
 
 	t.Run("Control", func(t *testing.T) {
 		start := time.Now()
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool onoff toggle 110 1 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 		assert.NoError(t,
 			os.WriteFile("chip-tool-thread-onoff.log", []byte(stdout), 0644),
 		)

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -44,7 +44,7 @@ func TestUpgrade(t *testing.T) {
 		allClustersSnap, "CHIP minimal mDNS started advertising", start)
 
 	t.Run("Commission", func(t *testing.T) {
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool pairing onnetwork 110 20202021 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
 		writeLogFile(t, "chip-tool-pairing", []byte(stdout))
 	})
 
@@ -54,7 +54,7 @@ func TestUpgrade(t *testing.T) {
 		log.Printf("%s installed version %s build %s\n", chipToolSnap, snapVersion, snapRevision)
 
 		start := time.Now()
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool onoff on 110 1 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool onoff on 110 1 2>&1")
 		writeLogFile(t, "chip-tool-onoff", []byte(stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
@@ -74,7 +74,7 @@ func TestUpgrade(t *testing.T) {
 		log.Printf("%s installed version %s build %s\n", chipToolSnap, snapVersion, snapRevision)
 
 		start := time.Now()
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool onoff off 110 1 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool onoff off 110 1 2>&1")
 		writeLogFile(t, "chip-tool-onoff", []byte(stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -34,12 +34,12 @@ func TestAllClustersAppWiFi(t *testing.T) {
 		allClustersSnap, "CHIP minimal mDNS started advertising", start)
 
 	t.Run("Commission", func(t *testing.T) {
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool pairing onnetwork 110 20202021 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
 		writeLogFile(t, "chip-tool-pairing", []byte(stdout))
 	})
 
 	t.Run("Control", func(t *testing.T) {
-		stdout, _, _ := utils.Exec(t, "sudo chip-tool onoff toggle 110 1 2>&1")
+		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 		writeLogFile(t, "chip-tool-toggle", []byte(stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)


### PR DESCRIPTION
## Summary
Chip Tool snap has changed and now works without root privileges:
https://github.com/canonical/chip-tool-snap/pull/55

Closes #63 
Depends on release Chip Tool snap v1.3.0.0+snap to latest/stable.


<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
