### PR TITLE
Use matter-snap-testing to handle log files

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: logs
-          path: tests/*.log
+          path: tests/logs/*.log
 
   publish-amd64:
     # Only publish if we are on the main branch

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,14 +1,11 @@
 package tests
 
 import (
-	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/canonical/matter-snap-testing/env"
 	"github.com/canonical/matter-snap-testing/utils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,12 +34,6 @@ func InstallChipTool(t *testing.T) {
 	utils.SnapConnect(t, chipToolSnap+":avahi-observe", "")
 	utils.SnapConnect(t, chipToolSnap+":bluez", "")
 	utils.SnapConnect(t, chipToolSnap+":process-control", "")
-}
-
-func writeLogFile(t *testing.T, label string, b []byte) {
-	assert.NoError(t,
-		os.WriteFile(strings.ReplaceAll(t.Name(), "/", "-")+"-"+label+".log", b, 0644),
-	)
 }
 
 func waitForOnOffHandlingByAllClustersApp(t *testing.T, start time.Time) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"github.com/canonical/matter-snap-testing/env"
 	"os"
 	"strings"
 	"testing"

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/canonical/matter-snap-testing/env"
 	"os"
 	"strings"
 	"testing"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,7 +5,7 @@ go 1.22.1
 toolchain go1.22.5
 
 require (
-	github.com/canonical/matter-snap-testing v1.0.0-beta.5
+	github.com/canonical/matter-snap-testing v1.0.0-beta.6
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.25.0
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -17,3 +17,5 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/canonical/matter-snap-testing => /home/jpmeijers/matter-snap-testing

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,7 +5,7 @@ go 1.22.1
 toolchain go1.22.5
 
 require (
-	github.com/canonical/matter-snap-testing v1.0.0-beta.4
+	github.com/canonical/matter-snap-testing v1.0.0-beta.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.25.0
 )
@@ -14,6 +14,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/sys v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -17,5 +17,3 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/canonical/matter-snap-testing => /home/jpmeijers/matter-snap-testing

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/matter-snap-testing v1.0.0-beta.5 h1:7OIHEtPUWCJH94qBZHvmmejOskPLby2oe7uHSwnR+yM=
-github.com/canonical/matter-snap-testing v1.0.0-beta.5/go.mod h1:gQqLfxxUD2Uo1Ua/L1uIuRhTVghAtdS54yhetTOeSIc=
+github.com/canonical/matter-snap-testing v1.0.0-beta.6 h1:t2x/gnRdAhkak4Pta+wP56kgE73MpTRUy2Wp6Sse5wo=
+github.com/canonical/matter-snap-testing v1.0.0-beta.6/go.mod h1:gQqLfxxUD2Uo1Ua/L1uIuRhTVghAtdS54yhetTOeSIc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/matter-snap-testing v1.0.0-beta.4 h1:fbmKYeGaIFAlugDBx6ehz0U10bG+WcFSgNBo36hxBL0=
-github.com/canonical/matter-snap-testing v1.0.0-beta.4/go.mod h1:gQqLfxxUD2Uo1Ua/L1uIuRhTVghAtdS54yhetTOeSIc=
+github.com/canonical/matter-snap-testing v1.0.0-beta.5 h1:7OIHEtPUWCJH94qBZHvmmejOskPLby2oe7uHSwnR+yM=
+github.com/canonical/matter-snap-testing v1.0.0-beta.5/go.mod h1:gQqLfxxUD2Uo1Ua/L1uIuRhTVghAtdS54yhetTOeSIc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,8 +13,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
 golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -2,6 +2,7 @@ package thread_tests
 
 import (
 	"fmt"
+	"github.com/canonical/matter-snap-testing/env"
 	"os"
 	"strings"
 	"testing"

--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -2,7 +2,6 @@ package thread_tests
 
 import (
 	"fmt"
-	"github.com/canonical/matter-snap-testing/env"
 	"os"
 	"strings"
 	"testing"

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -1,7 +1,6 @@
 package thread_tests
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -18,17 +17,15 @@ func TestAllClustersAppThread(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
-		assert.NoError(t,
-			os.WriteFile("chip-tool-thread-pairing.log", []byte(stdout), 0644),
-		)
+
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-pairing", []byte(stdout)))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
-		assert.NoError(t,
-			os.WriteFile("chip-tool-thread-onoff.log", []byte(stdout), 0644),
-		)
+
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-onoff", []byte(stdout)))
 
 		// 0x6 is the Matter Cluster ID for on-off
 		// Using cluster ID here because of a buffering issue in the log stream:

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -18,14 +18,14 @@ func TestAllClustersAppThread(t *testing.T) {
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
 
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-pairing", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-pairing", stdout))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-onoff", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-onoff", stdout))
 
 		// 0x6 is the Matter Cluster ID for on-off
 		// Using cluster ID here because of a buffering issue in the log stream:

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -18,14 +18,14 @@ func TestAllClustersAppThread(t *testing.T) {
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing code-thread 110 hex:"+trimmedActiveDataset+" 34970112332 2>&1")
 
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-pairing", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool", stdout))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-thread-onoff", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool", stdout))
 
 		// 0x6 is the Matter Cluster ID for on-off
 		// Using cluster ID here because of a buffering issue in the log stream:

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -14,7 +14,7 @@ func TestUpgrade(t *testing.T) {
 	start := time.Now()
 
 	t.Cleanup(func() {
-		// Remove snaps, ignoring errors
+		// Remove snaps, ignoring errors during removal
 		utils.SnapRemove(nil, allClustersSnap)
 		utils.SnapRemove(nil, chipToolSnap)
 

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -48,7 +48,7 @@ func TestUpgrade(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 	})
 
 	t.Run("Control before upgrade", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestUpgrade(t *testing.T) {
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff on 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})
@@ -71,14 +71,14 @@ func TestUpgrade(t *testing.T) {
 		}
 	})
 
-	t.Run("Control upgraded snap", func(t *testing.T) {
+	t.Run("Control after upgrade", func(t *testing.T) {
 		snapVersion := utils.SnapVersion(t, chipToolSnap)
 		snapRevision := utils.SnapRevision(t, chipToolSnap)
 		log.Printf("%s installed version %s build %s\n", chipToolSnap, snapVersion, snapRevision)
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff off 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/canonical/matter-snap-testing/env"
 	"log"
 	"testing"
 	"time"

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -48,7 +48,7 @@ func TestUpgrade(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", stdout))
 	})
 
 	t.Run("Control before upgrade", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestUpgrade(t *testing.T) {
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff on 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})
@@ -78,7 +78,7 @@ func TestUpgrade(t *testing.T) {
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff off 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"github.com/canonical/matter-snap-testing/env"
 	"log"
 	"testing"
 	"time"

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -7,16 +7,18 @@ import (
 
 	"github.com/canonical/matter-snap-testing/env"
 	"github.com/canonical/matter-snap-testing/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpgrade(t *testing.T) {
 	start := time.Now()
 
 	t.Cleanup(func() {
+		// Remove snaps, ignoring errors
 		utils.SnapRemove(nil, allClustersSnap)
-		utils.SnapDumpLogs(nil, start, allClustersSnap)
-
 		utils.SnapRemove(nil, chipToolSnap)
+
+		utils.SnapDumpLogs(t, start, allClustersSnap)
 	})
 
 	// Start clean
@@ -46,7 +48,7 @@ func TestUpgrade(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		writeLogFile(t, "chip-tool-pairing", []byte(stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", []byte(stdout)))
 	})
 
 	t.Run("Control before upgrade", func(t *testing.T) {
@@ -56,7 +58,7 @@ func TestUpgrade(t *testing.T) {
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff on 110 1 2>&1")
-		writeLogFile(t, "chip-tool-onoff", []byte(stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", []byte(stdout)))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})
@@ -76,7 +78,7 @@ func TestUpgrade(t *testing.T) {
 
 		start := time.Now()
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff off 110 1 2>&1")
-		writeLogFile(t, "chip-tool-onoff", []byte(stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-onoff", []byte(stdout)))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -36,12 +36,12 @@ func TestAllClustersAppWiFi(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", stdout))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-toggle", []byte(stdout)))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-toggle", stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -36,12 +36,12 @@ func TestAllClustersAppWiFi(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
-		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-toggle", stdout))
+		assert.NoError(t, utils.WriteLogFile(t, chipToolSnap, stdout))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/canonical/matter-snap-testing/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAllClustersAppWiFi(t *testing.T) {
@@ -35,12 +36,12 @@ func TestAllClustersAppWiFi(t *testing.T) {
 
 	t.Run("Commission", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool pairing onnetwork 110 20202021 2>&1")
-		writeLogFile(t, "chip-tool-pairing", []byte(stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-pairing", []byte(stdout)))
 	})
 
 	t.Run("Control", func(t *testing.T) {
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
-		writeLogFile(t, "chip-tool-toggle", []byte(stdout))
+		assert.NoError(t, utils.WriteLogFile(t, "chip-tool-toggle", []byte(stdout)))
 
 		waitForOnOffHandlingByAllClustersApp(t, start)
 	})


### PR DESCRIPTION
## Summary
Closes:
- #70 

Remove log file writing and rather use functions from matter-snap-testing

## Note
~~Requires https://github.com/canonical/matter-snap-testing/pull/33 to be merged and a new release to be made. Then we can bump the version of matter-snap-testing in `go.mod`.~~

~~The automated testing by Github actions will fail until we do this.~~

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->
All three tests are passing.

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
