### PR TITLE
Use lower risk level of dependency snaps in tests

### DIFF
--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -9,7 +9,6 @@ import (
 
 	tests "chip-tool-snap-tests"
 
-	"github.com/canonical/matter-snap-testing/env"
 	"github.com/canonical/matter-snap-testing/utils"
 )
 
@@ -20,7 +19,7 @@ func setup(t *testing.T) {
 	utils.SnapRemove(t, otbrSnap)
 
 	// Install OTBR
-	utils.SnapInstallFromStore(t, otbrSnap, env.SnapChannel())
+	utils.SnapInstallFromStore(t, otbrSnap, "latest/beta")
 	t.Cleanup(func() {
 		utils.SnapRemove(t, otbrSnap)
 	})

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -121,7 +121,7 @@ func remote_deployAllClustersApp(t *testing.T) {
 	commands := []string{
 		// "sudo apt install -y bluez",
 		"sudo snap remove --purge matter-all-clusters-app",
-		"sudo snap install matter-all-clusters-app --edge",
+		"sudo snap install matter-all-clusters-app --channel=latest/beta",
 		"sudo snap set matter-all-clusters-app args='--thread'",
 		"sudo snap connect matter-all-clusters-app:avahi-control",
 		// "sudo snap connect matter-all-clusters-app:bluez",

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -91,7 +91,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 
 	commands := []string{
 		"sudo snap remove --purge openthread-border-router",
-		"sudo snap install openthread-border-router --edge",
+		"sudo snap install openthread-border-router --beta",
 		fmt.Sprintf("sudo snap set openthread-border-router %s='%s'", infraInterfaceKey, remoteInfraInterface),
 		fmt.Sprintf("sudo snap set openthread-border-router %s='%s'", radioUrlKey, remoteRadioUrl),
 		// "sudo snap connect openthread-border-router:avahi-control",

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -91,7 +91,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 
 	commands := []string{
 		"sudo snap remove --purge openthread-border-router",
-		"sudo snap install openthread-border-router --beta",
+		"sudo snap install openthread-border-router --channel=latest/beta",
 		fmt.Sprintf("sudo snap set openthread-border-router %s='%s'", infraInterfaceKey, remoteInfraInterface),
 		fmt.Sprintf("sudo snap set openthread-border-router %s='%s'", radioUrlKey, remoteRadioUrl),
 		// "sudo snap connect openthread-border-router:avahi-control",

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -34,7 +34,7 @@ func TestUpgrade(t *testing.T) {
 	utils.SnapConnect(t, chipToolSnap+":process-control", "")
 
 	// Install all clusters app
-	utils.SnapInstallFromStore(t, allClustersSnap, env.SnapChannel())
+	utils.SnapInstallFromStore(t, allClustersSnap, "latest/beta")
 
 	// Setup all clusters app
 	utils.SnapSet(t, allClustersSnap, "args", "--wifi")

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -22,7 +22,7 @@ func TestAllClustersAppWiFi(t *testing.T) {
 	})
 
 	// Install all clusters app
-	utils.SnapInstallFromStore(t, allClustersSnap, "latest/edge")
+	utils.SnapInstallFromStore(t, allClustersSnap, "latest/beta")
 
 	// Setup all clusters app
 	utils.SnapSet(t, allClustersSnap, "args", "--wifi")


### PR DESCRIPTION
## Summary

Closes:
- #71 

The tests are meant to test unstable versions of ChipTool. Not unstable versions of matter-all-clusters-app or OTBR.

This PR pins the version of `matter-all-clusters-app` and `openthread-border-router` for the tests to `latest/beta`.

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->
All three tests are passing with these changes.

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
