### PR TITLE
Dumps logs even if test failed

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -13,6 +13,7 @@ const allClustersSnap = "matter-all-clusters-app"
 const chipToolSnap = "chip-tool"
 
 func InstallChipTool(t *testing.T) {
+	start := time.Now()
 
 	// clean
 	utils.SnapRemove(t, chipToolSnap)
@@ -28,6 +29,8 @@ func InstallChipTool(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		utils.SnapRemove(t, chipToolSnap)
+		logs := utils.SnapLogs(t, start, chipToolSnap)
+		utils.WriteLogFile(t, chipToolSnap, logs)
 	})
 
 	// connect interfaces

--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -1,7 +1,6 @@
 package thread_tests
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -19,9 +18,12 @@ func setup(t *testing.T) {
 	utils.SnapRemove(t, otbrSnap)
 
 	// Install OTBR
+	otbrInstallTime := time.Now()
 	utils.SnapInstallFromStore(t, otbrSnap, "latest/beta")
 	t.Cleanup(func() {
 		utils.SnapRemove(t, otbrSnap)
+		logs := utils.SnapLogs(t, otbrInstallTime, otbrSnap)
+		utils.WriteLogFile(t, otbrSnap, logs)
 	})
 
 	// Connect interfaces
@@ -47,16 +49,16 @@ func setup(t *testing.T) {
 	}
 
 	// Start OTBR
-	start := time.Now()
+	otbrStartTime := time.Now()
 	utils.SnapStart(t, otbrSnap)
-	waitForLogMessage(t, otbrSnap, "Start Thread Border Agent: OK", start)
+	utils.WaitForLogMessage(t, otbrSnap, "Start Thread Border Agent: OK", otbrStartTime)
 
 	// Form Thread network
 	utils.Exec(t, "sudo "+OTCTL+" dataset init new")
 	utils.Exec(t, "sudo "+OTCTL+" dataset commit active")
 	utils.Exec(t, "sudo "+OTCTL+" ifconfig up")
 	utils.Exec(t, "sudo "+OTCTL+" thread start")
-	utils.WaitForLogMessage(t, otbrSnap, "Thread Network", start)
+	utils.WaitForLogMessage(t, otbrSnap, "Thread Network", otbrStartTime)
 }
 
 func getActiveDataset(t *testing.T) string {
@@ -64,27 +66,4 @@ func getActiveDataset(t *testing.T) string {
 	trimmedActiveDataset := strings.TrimSpace(activeDataset)
 
 	return trimmedActiveDataset
-}
-
-// TODO: update the library function to print the tail before failing:
-// https://github.com/canonical/matter-snap-testing/blob/abae29ac5e865f0c5208350bdab63cecb3bdcc5a/utils/config.go#L54-L69
-func waitForLogMessage(t *testing.T, snap, expectedLog string, since time.Time) {
-	const maxRetry = 10
-
-	for i := 1; i <= maxRetry; i++ {
-		time.Sleep(1 * time.Second)
-		t.Logf("Retry %d/%d: Waiting for expected content in logs: %s", i, maxRetry, expectedLog)
-
-		logs := utils.SnapLogs(t, since, snap)
-		if strings.Contains(logs, expectedLog) {
-			t.Logf("Found expected content in logs: %s", expectedLog)
-			return
-		}
-	}
-
-	t.Logf("Time out: reached max %d retries.", maxRetry)
-	stdout, _, _ := utils.Exec(t,
-		fmt.Sprintf("sudo journalctl --lines=10 --no-pager --unit=snap.\"%s\".otbr-agent --priority=notice", snap))
-	t.Log(stdout)
-	t.FailNow()
 }

--- a/tests/thread_tests/local.go
+++ b/tests/thread_tests/local.go
@@ -21,9 +21,9 @@ func setup(t *testing.T) {
 	otbrInstallTime := time.Now()
 	utils.SnapInstallFromStore(t, otbrSnap, "latest/beta")
 	t.Cleanup(func() {
-		utils.SnapRemove(t, otbrSnap)
 		logs := utils.SnapLogs(t, otbrInstallTime, otbrSnap)
 		utils.WriteLogFile(t, otbrSnap, logs)
+		utils.SnapRemove(t, otbrSnap)
 	})
 
 	// Connect interfaces

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -86,8 +86,8 @@ func remote_deployOTBRAgent(t *testing.T) {
 	start := time.Now().UTC()
 
 	t.Cleanup(func() {
-		remote_exec(t, "sudo snap remove --purge openthread-border-router")
 		dumpRemoteLogs(t, "openthread-border-router", start)
+		remote_exec(t, "sudo snap remove --purge openthread-border-router")
 	})
 
 	commands := []string{
@@ -115,8 +115,8 @@ func remote_deployAllClustersApp(t *testing.T) {
 	start := time.Now().UTC()
 
 	t.Cleanup(func() {
-		remote_exec(t, "sudo snap remove --purge matter-all-clusters-app")
 		dumpRemoteLogs(t, "matter-all-clusters-app", start)
+		remote_exec(t, "sudo snap remove --purge matter-all-clusters-app")
 	})
 
 	commands := []string{

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -87,7 +87,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge openthread-border-router")
-		remoteDumpLogs(t, "openthread-border-router", start)
+		dumpRemoteLogs(t, "openthread-border-router", start)
 	})
 
 	commands := []string{
@@ -116,7 +116,7 @@ func remote_deployAllClustersApp(t *testing.T) {
 
 	t.Cleanup(func() {
 		remote_exec(t, "sudo snap remove --purge matter-all-clusters-app")
-		remoteDumpLogs(t, "matter-all-clusters-app", start)
+		dumpRemoteLogs(t, "matter-all-clusters-app", start)
 	})
 
 	commands := []string{
@@ -193,7 +193,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 	t.FailNow()
 }
 
-func remoteDumpLogs(t *testing.T, label string, start time.Time) error {
+func dumpRemoteLogs(t *testing.T, label string, start time.Time) error {
 	command := fmt.Sprintf("sudo journalctl --utc --since \"%s\" --no-pager | grep \"%s\"|| true", start.UTC().Format("2006-01-02 15:04:05"), label)
 	logs := remote_exec(t, command)
 	return utils.WriteLogFile(t, "remote-"+label, logs)

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -14,11 +14,12 @@ func TestUpgrade(t *testing.T) {
 	start := time.Now()
 
 	t.Cleanup(func() {
+		utils.SnapDumpLogs(t, start, allClustersSnap)
+		utils.SnapDumpLogs(t, start, chipToolSnap)
+
 		// Remove snaps, ignoring errors during removal
 		utils.SnapRemove(nil, allClustersSnap)
 		utils.SnapRemove(nil, chipToolSnap)
-
-		utils.SnapDumpLogs(t, start, allClustersSnap)
 	})
 
 	// Start clean

--- a/tests/wifi_test.go
+++ b/tests/wifi_test.go
@@ -17,8 +17,8 @@ func TestAllClustersAppWiFi(t *testing.T) {
 	utils.SnapRemove(t, allClustersSnap)
 
 	t.Cleanup(func() {
-		utils.SnapRemove(t, allClustersSnap)
 		utils.SnapDumpLogs(t, start, allClustersSnap)
+		utils.SnapRemove(t, allClustersSnap)
 	})
 
 	// Install all clusters app


### PR DESCRIPTION
## Summary

Affected:
- Solves #75 

Dump journal entries for snaps in test cleanup, after uninstall. This allows logs to be dumped, even if the tests failed.

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->

Check that log files are written even if tests fail:
* Set the LOCAL_INFRA_IF value to something that does not exist
* Set the REMOTE_INFRA_IF value to something that does not exist

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
