### PR TITLE
Use sudo -S argument to pipe in password

### DIFF
--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -142,6 +142,12 @@ func remote_exec(t *testing.T, command string) string {
 
 	t.Logf("[exec-ssh] %s", command)
 
+	// Remote commands that require sudo might ask for the password. Always pass it in. See https://stackoverflow.com/a/11955358
+	if strings.HasPrefix(command, "sudo ") {
+		command = command[5:] // remove "sudo "
+		command = "echo \"" + remotePassword + "\" | sudo -S " + command
+	}
+
 	if SSHClient == nil {
 		t.Fatalf("SSH client not initialized. Please connect to remote device first")
 	}

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -144,9 +144,9 @@ func remote_exec(t *testing.T, command string) string {
 
 	// Remote commands that require sudo might ask for the password. Always pass it in. See https://stackoverflow.com/a/11955358
 	if strings.HasPrefix(command, "sudo ") {
-		command = command[5:]
+		command = strings.TrimPrefix(command, "sudo ")
 		escapedPassword := strings.Replace(remotePassword, "\"", "\\\"", -1)
-		command = "echo \"" + escapedPassword + "\" | sudo -S " + command
+		command = fmt.Sprintf(`echo "%s" | sudo -S %s`, escapedPassword, command)
 	}
 
 	if SSHClient == nil {

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -145,7 +145,7 @@ func remote_exec(t *testing.T, command string) string {
 	// Remote commands that require sudo might ask for the password. Always pass it in. See https://stackoverflow.com/a/11955358
 	if strings.HasPrefix(command, "sudo ") {
 		command = strings.TrimPrefix(command, "sudo ")
-		escapedPassword := strings.Replace(remotePassword, "\"", "\\\"", -1)
+		escapedPassword := strings.ReplaceAll(remotePassword, `"`, `\"`)
 		command = fmt.Sprintf(`echo "%s" | sudo -S %s`, escapedPassword, command)
 	}
 

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -144,8 +144,9 @@ func remote_exec(t *testing.T, command string) string {
 
 	// Remote commands that require sudo might ask for the password. Always pass it in. See https://stackoverflow.com/a/11955358
 	if strings.HasPrefix(command, "sudo ") {
-		command = command[5:] // remove "sudo "
-		command = "echo \"" + remotePassword + "\" | sudo -S " + command
+		command = command[5:]
+		escapedPassword := strings.Replace(remotePassword, "\"", "\\\"", -1)
+		command = "echo \"" + escapedPassword + "\" | sudo -S " + command
 	}
 
 	if SSHClient == nil {


### PR DESCRIPTION
## Summary

Related:
- Solves #72

Remote devices might ask for a sudo password. To prevent sudo from expecting a password from the keyboard, we use the `-S` argument to pipe in the password via stdin.

## Testing Steps
<!-- Steps to test the changes. Remove if not relevant -->

* Tested on an Ubuntu Desktop remote device that asks for a sudo password.
* Tested on an Ubuntu Server remote device that does not ask for a sudo password.

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
