### PR TITLE
test: use Unix timestamp from remote machine as reference for two machine tests

### DIFF
--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -82,7 +82,7 @@ func connectSSH(t *testing.T) {
 	t.Logf("SSH: connected to %s", remoteHost)
 }
 
-func getStartTimestamp(t *testing.T) time.Time {
+func getRemoteStartTime(t *testing.T) time.Time {
 	t.Helper()
 	// Get the current unix timestamp on the remote device
 	start := remote_exec(t, "date +%s")
@@ -96,7 +96,7 @@ func getStartTimestamp(t *testing.T) time.Time {
 }
 
 func remote_deployOTBRAgent(t *testing.T) {
-	start := getStartTimestamp(t)
+	start := getRemoteStartTime(t)
 
 	t.Cleanup(func() {
 		dumpRemoteLogs(t, "openthread-border-router", start)
@@ -125,7 +125,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 }
 
 func remote_deployAllClustersApp(t *testing.T) {
-	start := getStartTimestamp(t)
+	start := getRemoteStartTime(t)
 
 	t.Cleanup(func() {
 		dumpRemoteLogs(t, "matter-all-clusters-app", start)

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -200,9 +200,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 		time.Sleep(1 * time.Second)
 		t.Logf("Retry %d/%d: Waiting for expected content in logs: '%s'", i, maxRetry, expectedLog)
 
-		// Use Unix timestamp which is timezone-independent
-		// journalctl accepts timestamps in the format @UNIX_TIMESTAMP
-		command := fmt.Sprintf("sudo journalctl --since @%d --no-pager | grep \"%s\" || true", start.Unix(), snap)
+		command := fmt.Sprintf("sudo journalctl --since %q --no-pager | grep \"%s\" || true", start.Format(time.RFC3339), snap)
 		logs := remote_exec(t, command)
 		if strings.Contains(logs, expectedLog) {
 			t.Logf("Found expected content in logs: '%s'", expectedLog)
@@ -216,7 +214,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 }
 
 func dumpRemoteLogs(t *testing.T, label string, start time.Time) error {
-	command := fmt.Sprintf("sudo journalctl --since @%d --no-pager | grep \"%s\" || true", start.Unix(), label)
+	command := fmt.Sprintf("sudo journalctl --since %q --no-pager | grep \"%s\" || true", start.Format(time.RFC3339), label)
 	logs := remote_exec(t, command)
 	return utils.WriteLogFile(t, "remote-"+label, logs)
 }

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -202,7 +202,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 
 		// Use Unix timestamp which is timezone-independent
 		// journalctl accepts timestamps in the format @UNIX_TIMESTAMP
-		command := fmt.Sprintf("sudo journalctl --since @%d --no-pager | grep \"%s\" || true", start, snap)
+		command := fmt.Sprintf("sudo journalctl --since @%d --no-pager | grep \"%s\" || true", start.Unix(), snap)
 		logs := remote_exec(t, command)
 		if strings.Contains(logs, expectedLog) {
 			t.Logf("Found expected content in logs: '%s'", expectedLog)

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -4,18 +4,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/canonical/matter-snap-testing/utils"
 	"golang.org/x/crypto/ssh"
-)
-
-const (
-	// Adding a 120 seconds offset to account for any clock skew
-	// between the local and remote machine.
-	ClockOffset = 120 // seconds
 )
 
 var (
@@ -87,8 +82,21 @@ func connectSSH(t *testing.T) {
 	t.Logf("SSH: connected to %s", remoteHost)
 }
 
+func getStartTimestamp(t *testing.T) int64 {
+	t.Helper()
+	// Get the current unix timestamp on the remote device
+	start := remote_exec(t, "date +%s")
+	start = strings.TrimSpace(start)
+	start = strings.TrimSuffix(start, "\n")
+	startTimestamp, err := strconv.ParseInt(start, 10, 64)
+	if err != nil {
+		t.Fatalf("Failed to parse start timestamp: %v", err)
+	}
+	return startTimestamp
+}
+
 func remote_deployOTBRAgent(t *testing.T) {
-	start := time.Now()
+	start := getStartTimestamp(t)
 
 	t.Cleanup(func() {
 		dumpRemoteLogs(t, "openthread-border-router", start)
@@ -117,7 +125,7 @@ func remote_deployOTBRAgent(t *testing.T) {
 }
 
 func remote_deployAllClustersApp(t *testing.T) {
-	start := time.Now()
+	start := getStartTimestamp(t)
 
 	t.Cleanup(func() {
 		dumpRemoteLogs(t, "matter-all-clusters-app", start)
@@ -184,7 +192,7 @@ func remote_exec(t *testing.T, command string) string {
 	return string(output)
 }
 
-func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, start time.Time) {
+func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, startTimestamp int64) {
 	t.Helper()
 
 	const maxRetry = 10
@@ -194,7 +202,7 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 
 		// Use Unix timestamp which is timezone-independent
 		// journalctl accepts timestamps in the format @UNIX_TIMESTAMP
-		command := fmt.Sprintf("sudo journalctl --since \"@%d\" --no-pager | grep \"%s\" || true", start.Unix()-ClockOffset, snap)
+		command := fmt.Sprintf("sudo journalctl --since \"@%d\" --no-pager | grep \"%s\" || true", startTimestamp, snap)
 		logs := remote_exec(t, command)
 		if strings.Contains(logs, expectedLog) {
 			t.Logf("Found expected content in logs: '%s'", expectedLog)
@@ -207,8 +215,8 @@ func remote_waitForLogMessage(t *testing.T, snap string, expectedLog string, sta
 	t.FailNow()
 }
 
-func dumpRemoteLogs(t *testing.T, label string, start time.Time) error {
-	command := fmt.Sprintf("sudo journalctl --since \"@%d\" --no-pager | grep \"%s\" || true", start.Unix()-ClockOffset, label)
+func dumpRemoteLogs(t *testing.T, label string, startTimestamp int64) error {
+	command := fmt.Sprintf("sudo journalctl --since \"@%d\" --no-pager | grep \"%s\" || true", startTimestamp, label)
 	logs := remote_exec(t, command)
 	return utils.WriteLogFile(t, "remote-"+label, logs)
 }

--- a/tests/thread_tests/remote.go
+++ b/tests/thread_tests/remote.go
@@ -87,7 +87,6 @@ func getRemoteStartTime(t *testing.T) time.Time {
 	// Get the current unix timestamp on the remote device
 	start := remote_exec(t, "date +%s")
 	start = strings.TrimSpace(start)
-	start = strings.TrimSuffix(start, "\n")
 	startTimestamp, err := strconv.ParseInt(start, 10, 64)
 	if err != nil {
 		t.Fatalf("Failed to parse start timestamp: %v", err)

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -21,7 +21,7 @@ func TestAllClustersAppThread(t *testing.T) {
 	})
 
 	t.Run("Control", func(t *testing.T) {
-		start := getStartTimestamp(t)
+		start := getRemoteStartTime(t)
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 
 		assert.NoError(t, utils.WriteLogFile(t, "chip-tool", stdout))

--- a/tests/thread_tests/thread_test.go
+++ b/tests/thread_tests/thread_test.go
@@ -2,7 +2,6 @@ package thread_tests
 
 import (
 	"testing"
-	"time"
 
 	"github.com/canonical/matter-snap-testing/utils"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ func TestAllClustersAppThread(t *testing.T) {
 	})
 
 	t.Run("Control", func(t *testing.T) {
-		start := time.Now()
+		start := getStartTimestamp(t)
 		stdout, _, _ := utils.Exec(t, "chip-tool onoff toggle 110 1 2>&1")
 
 		assert.NoError(t, utils.WriteLogFile(t, "chip-tool", stdout))
@@ -32,5 +31,4 @@ func TestAllClustersAppThread(t *testing.T) {
 		// https://github.com/canonical/chip-tool-snap/pull/69#issuecomment-2209530275
 		remote_waitForLogMessage(t, "matter-all-clusters-app", "ClusterId = 0x6", start)
 	})
-
 }


### PR DESCRIPTION
## Summary

When discussed internally the issue https://github.com/canonical/chip-tool-snap/issues/85, one of the possibilities raised was that because I'm in `America/Sao_Paulo` timezone, which is a "negative timezone" compared to `UTC` the test would be looking into some time in the future that didn't happen yet and by doing so fail to find the necessary logs.

Then I switch on my Raspberry Pi the timezone to a "positive timezone" like `Europe/Berlin` and try again, and this time the tests passes.

So the guess was correct. That's why we have different behaviors when comparing my results to the other people on Europe.

But, even after correcting the time (using absolute UNIX timestamp instead of timezones), I still continue to have some problems, after a little bit of investigation, I found that this was due to the times on the machines weren't perfectly synchronized (usually a few seconds off already causes problems). And seems that for my case, it was a considerable amount of seconds.


I did this experiment for running `date` command on my computer and on my **Raspberry Pi 5** sequentially and this is what I got:
```console
$ date && ssh ubuntu@borr.local "date"
Wed Aug 20 06:32:01 PM -03 2025
Wed Aug 20 18:30:53 -03 2025
``` 
Ignoring the 12hr vs 24hr format difference, and of course there are a few milliseconds spent on the ssh connection, but still there is a difference of more than 1minute.

So, this looks like an interesting use case for Precision Time Protocol. But to don't overcomplicate things and add more variables to the test, I decided to fetch the Unix timestamp from the remote machine at the beginning of the test and use this as reference for fetching the logs.

## Related issues
- Closes: https://github.com/canonical/chip-tool-snap/issues/85

## Testing steps

- On the remote machine:
  - set the timezone to a "negative timezone", something like `America/Sao_Paulo` (GMT-3:00) and run the thread tests
  - set the timezone to `UTC` and run the thread tests
  - set the timezone to your local timezone and run the thread tests

It should work on all three scenarios.

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
