### PR TITLE
Update CHIP_TAG to v1.5-branch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ parts:
     plugin: nil
     build-environment:
       - BUILD_METADATA: snap
-      - CHIP_TAG: master
+      - CHIP_TAG: v1.5-branch
     override-pull: |
       # shallow clone the project and its submodules
       git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=$CHIP_TAG .


### PR DESCRIPTION


## Summary
Switch to `v1.5-branch` to release v1.5.0 chip-tool to build Matter v1.5 release.

## Related issues
#90

## Testing steps
```
sudo snapcraft pack
Building connectedhomeip / (23.6s)
Building connectedhomeip | (23.9s)
```

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
